### PR TITLE
ci: fix clippy breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ matrix:
       rust: nightly
       env: TYPE=rustfmt RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install rustfmt || true)
+        - cargo install rustfmt -f || exit 0
         - cargo fmt -- --write-mode=diff
     - os: linux
       rust: nightly
       env: TYPE=clippy RUST_BACKTRACE=1
       script:
-        - (travis_wait 20 cargo install clippy || true)
+        - cargo install clippy -f || exit 0
         - cargo clippy


### PR DESCRIPTION
- clippy failed due to clippy/nightly breakage, skip if install fails