### PR TITLE
fix: rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       rust: nightly
       env: TYPE=rustfmt RUST_BACKTRACE=1
       script:
-        - cargo install rustfmt -f || exit 0
+        - cargo install rustfmt -f --vers 0.8.4 || exit 0
         - cargo fmt -- --write-mode=diff
     - os: linux
       rust: nightly


### PR DESCRIPTION
- pin to 0.8.4 as 0.8.6 produces incorrect code