### PR TITLE
feature: support realtime clock equivalent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ description = "clocksource provides TSC access with transparent fallback to cloc
 keywords = [ "clock", "time" ]
 
 [dependencies]
+allan = "*"
 libc = "0.2.15"
 
 [features]

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -42,37 +42,37 @@ fn test_clock(reference: Clock, source: Clock) {
     println!("Stability:");
     if let Some(t) = allan.get(1) {
         if let Some(adev) = t.deviation() {
-        	let tdev = (1.0f64 / (3.0f64).powf(0.5)) * adev;
+            let tdev = (1.0f64 / (3.0f64).powf(0.5)) * adev;
             println!("     TDEV(1mS): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(10) {
         if let Some(adev) = t.deviation() {
-        	let tdev = (10.0f64 / (3.0f64).powf(0.5)) * adev;
+            let tdev = (10.0f64 / (3.0f64).powf(0.5)) * adev;
             println!("    TDEV(10mS): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(100) {
         if let Some(adev) = t.deviation() {
-        	let tdev = (100.0f64 / (3.0f64).powf(0.5)) * adev;
+            let tdev = (100.0f64 / (3.0f64).powf(0.5)) * adev;
             println!("   TDEV(100mS): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(1_000) {
         if let Some(adev) = t.deviation() {
-        	let tdev = (1_000.0f64 / (3.0f64).powf(0.5)) * adev;
+            let tdev = (1_000.0f64 / (3.0f64).powf(0.5)) * adev;
             println!("      TDEV(1S): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(10_000) {
         if let Some(adev) = t.deviation() {
-        	let tdev = (10_000.0f64 / (3.0f64).powf(0.5)) * adev;
+            let tdev = (10_000.0f64 / (3.0f64).powf(0.5)) * adev;
             println!("     TDEV(10S): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(100_000) {
         if let Some(adev) = t.deviation() {
-        	let tdev = (100_000.0f64 / (3.0f64).powf(0.5)) * adev;
+            let tdev = (100_000.0f64 / (3.0f64).powf(0.5)) * adev;
             println!("    TDEV(100S): {:.3e}", tdev);
         }
     }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -42,32 +42,38 @@ fn test_clock(reference: Clock, source: Clock) {
     println!("Stability:");
     if let Some(t) = allan.get(1) {
         if let Some(adev) = t.deviation() {
-            println!("     ADEV(1mS): {:.3e}", adev);
+        	let tdev = (1.0f64 / (3.0f64).powf(0.5)) * adev;
+            println!("     TDEV(1mS): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(10) {
         if let Some(adev) = t.deviation() {
-            println!("    ADEV(10mS): {:.3e}", adev);
+        	let tdev = (10.0f64 / (3.0f64).powf(0.5)) * adev;
+            println!("    TDEV(10mS): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(100) {
         if let Some(adev) = t.deviation() {
-            println!("   ADEV(100mS): {:.3e}", adev);
+        	let tdev = (100.0f64 / (3.0f64).powf(0.5)) * adev;
+            println!("   TDEV(100mS): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(1_000) {
         if let Some(adev) = t.deviation() {
-            println!("      ADEV(1S): {:.3e}", adev);
+        	let tdev = (1_000.0f64 / (3.0f64).powf(0.5)) * adev;
+            println!("      TDEV(1S): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(10_000) {
         if let Some(adev) = t.deviation() {
-            println!("     ADEV(10S): {:.3e}", adev);
+        	let tdev = (10_000.0f64 / (3.0f64).powf(0.5)) * adev;
+            println!("     TDEV(10S): {:.3e}", tdev);
         }
     }
     if let Some(t) = allan.get(100_000) {
         if let Some(adev) = t.deviation() {
-            println!("    ADEV(100S): {:.3e}", adev);
+        	let tdev = (100_000.0f64 / (3.0f64).powf(0.5)) * adev;
+            println!("    TDEV(100S): {:.3e}", tdev);
         }
     }
 }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -1,21 +1,73 @@
+extern crate allan;
 extern crate clocksource;
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use allan::{Allan, Style};
+use clocksource::{Clock, Clocksource};
 use std::thread;
+use std::time::Duration;
 
 fn main() {
-	let clock = clocksource::Clocksource::new();
-	for _ in 0..60 {
-		let cs_time = clock.time();
-		let sys_time = SystemTime::now();
-		let sys_dur = sys_time.duration_since(UNIX_EPOCH).expect("failure getting system time");
-		let sys_time = sys_dur.as_secs() * 1_000_000_000 + sys_dur.subsec_nanos() as u64;
+    println!("Calculating stability of time estimators... runtime ~15 minutes");
 
-		let delta = cs_time as i64 - sys_time as i64;
+    println!("Baseline:");
+    test_clock(Clock::Monotonic, Clock::Monotonic);
 
-		println!("Clocksource: {} System: {} Delta: {}", cs_time, sys_time, delta);
-		thread::sleep(Duration::new(1, 0));
+    println!("Realtime:");
+    test_clock(Clock::Realtime, Clock::Counter);
 
-	}
+    println!("Monotonic:");
+    test_clock(Clock::Monotonic, Clock::Counter);
+}
 
+fn test_clock(reference: Clock, source: Clock) {
+    println!("Reference: {:?} Source: {:?}", reference, source);
+    let clock = Clocksource::configured(reference, source);
+
+    let mut allan = Allan::configure()
+        .max_tau(100_000)
+        .style(Style::Decade)
+        .build()
+        .unwrap();
+
+    for _ in 0..300_000 {
+        let time = clock.time();
+        let ref_time = clock.reference();
+
+        let delta = (time as f64 - ref_time as f64) / 1_000_000_000.0;
+        allan.record(delta);
+
+        thread::sleep(Duration::new(0, 1_000_000));
+    }
+
+    println!("Stability:");
+    if let Some(t) = allan.get(1) {
+        if let Some(adev) = t.deviation() {
+            println!("     ADEV(1mS): {:.3e}", adev);
+        }
+    }
+    if let Some(t) = allan.get(10) {
+        if let Some(adev) = t.deviation() {
+            println!("    ADEV(10mS): {:.3e}", adev);
+        }
+    }
+    if let Some(t) = allan.get(100) {
+        if let Some(adev) = t.deviation() {
+            println!("   ADEV(100mS): {:.3e}", adev);
+        }
+    }
+    if let Some(t) = allan.get(1_000) {
+        if let Some(adev) = t.deviation() {
+            println!("      ADEV(1S): {:.3e}", adev);
+        }
+    }
+    if let Some(t) = allan.get(10_000) {
+        if let Some(adev) = t.deviation() {
+            println!("     ADEV(10S): {:.3e}", adev);
+        }
+    }
+    if let Some(t) = allan.get(100_000) {
+        if let Some(adev) = t.deviation() {
+            println!("    ADEV(100S): {:.3e}", adev);
+        }
+    }
 }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -1,0 +1,21 @@
+extern crate clocksource;
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::thread;
+
+fn main() {
+	let clock = clocksource::Clocksource::new();
+	for _ in 0..60 {
+		let cs_time = clock.time();
+		let sys_time = SystemTime::now();
+		let sys_dur = sys_time.duration_since(UNIX_EPOCH).expect("failure getting system time");
+		let sys_time = sys_dur.as_secs() * 1_000_000_000 + sys_dur.subsec_nanos() as u64;
+
+		let delta = cs_time as i64 - sys_time as i64;
+
+		println!("Clocksource: {} System: {} Delta: {}", cs_time, sys_time, delta);
+		thread::sleep(Duration::new(1, 0));
+
+	}
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ fn get_precise_ns() -> u64 {
         tv_nsec: 0,
     };
     unsafe {
-        libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
+        libc::clock_gettime(libc::CLOCK_REALTIME, &mut ts);
     }
     (ts.tv_sec as u64) * 1_000_000_000 + (ts.tv_nsec as u64)
 }


### PR DESCRIPTION
This PR addresses the feature request in #10 and closes the issue. 

Support producing `CLOCK_REALTIME` approximations from the TSC. This produces nanoseconds since unix epoch - and should be reasonably accurate as long as the `Clocksource` is periodically recalibrated. This can be done outside of the hot-path and swapped in. 

Future efforts might be able to handle the calibration in a non-blocking fashion and allow for a more active roll in maintaining an accurate paper clock from the TSC readings.