### PR TITLE
Change non unix to std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ libc = "0.2.15"
 lazy_static = "1.0"
 winapi = { version = "0.3.4", features = ["profileapi", "sysinfoapi"] }
 
+[target.'cfg(not(unix))'.dependencies]
+lazy_static = "1.0"
+
 [dev-dependencies]
 allan = "0.2.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,11 @@ impl Clocksource {
 
     /// converts a raw reading to approximation of reference in nanoseconds
     pub fn convert(&self, src_t1: u64) -> f64 {
-        (self.ref_hz * (src_t1.wrapping_sub(self.src_t0) as f64 / self.src_hz)) + self.ref_t0 as f64
+        if self.src_id != self.ref_id {
+            (self.ref_hz * ((src_t1 - self.src_t0) as f64 / self.src_hz)) + self.ref_t0 as f64
+        } else {
+            src_t1 as f64
+        }
     }
 }
 


### PR DESCRIPTION
This PR just changes the default non-unix behavior to use the target's standard library, instead of libc.