### PR TITLE
update mac clocksources to reflect deprecation of mach in libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ libc = "0.2.15"
 lazy_static = "1.0"
 winapi = { version = "0.3.4", features = ["profileapi", "sysinfoapi"] }
 
-[target.'cfg(not(unix))'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+mach = "0.3"
+
+[target.'cfg(all(not(windows), not(unix), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
 lazy_static = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Update mac source to appease new compiler (and because the old code is deprecated)