### PR TITLE
release: v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0] - 2026-03-20
+
+First release with changelog.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clocksource"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 authors = ["Brian Martin <brian@iop.systems>"]
 edition = "2024"
 description = "Library for times and durations with fixed-size representations"


### PR DESCRIPTION
## Release v1.0.0

This PR prepares the release of v1.0.0.

### Changes
- Version bump to 1.0.0
- Changelog update

### After Merge
The tag-release workflow will automatically:
1. Create git tag `v1.0.0`
2. Trigger CI + publish to crates.io
3. Create a GitHub Release
4. Bump to next development version (`1.0.1-alpha.0`)

---
See CHANGELOG.md for details.